### PR TITLE
Added a background color to the image picker

### DIFF
--- a/assets/source/css/imagemanager.input.css
+++ b/assets/source/css/imagemanager.input.css
@@ -3,4 +3,4 @@
 #modal-imagemanager iframe{ border: none; width: 100%; min-height: 500px; }
 
 .image-manager-input{}
-.image-manager-input .img-preview{ margin-top: 10px; max-width: 200px; max-height: 200px; }
+.image-manager-input .img-preview{ margin-top: 10px; max-width: 200px; max-height: 200px; background: #393939; padding: 0;}

--- a/assets/source/css/imagemanager.module.css
+++ b/assets/source/css/imagemanager.module.css
@@ -6,7 +6,8 @@
 #module-imagemanager > .row .col-overview{ padding-left: 0; padding-right: 0; border-right: 1px solid #ddd; height: 100%; overflow: auto; }
 #module-imagemanager > .row .col-overview .item-overview{ max-height: 500px; overflow: auto; }
 #module-imagemanager > .row .col-overview .item-overview .item{ position: relative; overflow: hidden; width: 128px; height: 128px; cursor: pointer; }
-#module-imagemanager > .row .col-overview .item-overview .item.selected{ background: #00ac24; }
+#module-imagemanager > .row .col-overview .item-overview .item.selected { background: white; }
+#module-imagemanager > .row .col-overview .item-overview .item.selected .thumbnail { background: #00ac24; }
 #module-imagemanager > .row .col-overview .item-overview .item .thumbnail{ margin-bottom: 0; }
 #module-imagemanager > .row .col-overview .item-overview .item .thumbnail img{ max-height: 118px; }
 #module-imagemanager > .row .col-overview .item-overview .item .thumbnail .filename{ background-color: rgba(255, 255, 255, 0.9); position: absolute; bottom: 4px; left: 4px; right: 4px; max-height: 100%; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; padding: 0 10px; }
@@ -24,8 +25,8 @@
 #module-imagemanager > .row .col-options .form-group .btn-add-flyleaf{ float: left; }
 /*details*/
 #module-imagemanager > .row .col-options .image-info{ margin-top: 10px; }
-#module-imagemanager > .row .col-options .image-info .thumbnail{ margin-bottom: 10px; }
-#module-imagemanager > .row .col-options .image-info .thumbnail img{ max-width: 100%; }
+#module-imagemanager > .row .col-options .image-info .thumbnail{ margin-bottom: 10px; background: #393939; padding: 0; }
+#module-imagemanager > .row .col-options .image-info .thumbnail img{ max-width: 100%; border-radius: 4px; }
 #module-imagemanager > .row .col-options .image-info .edit-buttons{ margin-bottom: 10px; }
 #module-imagemanager > .row .col-options .image-info .details{}
 #module-imagemanager > .row .col-options .image-info .details .fileName{ font-weight: bold; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }


### PR DESCRIPTION
The image picker shows a grey background on transparent images, so that when the transparent image is white, they still show their content.
