### PR TITLE
Variable added to prevent user from deleting image from the image manager

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -23,11 +23,18 @@ class Module extends \yii\base\Module
 	public $assetPublishedUrl;
 
     /**
-     * @var bool|mixed Variable that defines if the delete action will be available
+     * @var bool|callable Variable that defines if the delete action will be available
      * This variable default to true, to enable removal if image
      * It is also possible to give a callable function, in which case the function will be executed
      */
-    public $removeImageAllowed = true;
+    public $canRemoveImage = true;
+
+    /**
+     * @var bool|callable Variable that defines if the upload action will be available
+     * This variable defaults to true, to enable uploading by default
+     * It is also possible to give a callable function, in which case the function will be executed
+     */
+    public $canUploadImage = true;
 
     /**
      * @inheritdoc
@@ -52,9 +59,14 @@ class Module extends \yii\base\Module
 		//set asset path
 		$this->assetPublishedUrl = (new AssetManager)->getPublishedUrl("@vendor/noam148/yii2-image-manager/assets/source");
 
-        // Check if the removeImageAllowed variable is callable
-        if (is_callable($this->removeImageAllowed)) {
-            $this->removeImageAllowed = call_user_func($this->removeImageAllowed);
+        // Check if the canRemoveImage variable is callable
+        if (is_callable($this->canRemoveImage)) {
+            $this->canRemoveImage = call_user_func($this->canRemoveImage);
+        }
+
+        // Check if the canUploadImage variable is callable
+        if (is_callable($this->canUploadImage)) {
+            $this->canUploadImage = call_user_func($this->canUploadImage);
         }
 
         // Check if the variable configuration is correct in order for the module to function
@@ -113,10 +125,19 @@ class Module extends \yii\base\Module
         }
 	}
 
+    /**
+     * Check if the module variables have the content that is expected
+     * @throws InvalidConfigException
+     */
 	private function _checkVariableConfiguration() {
-        // Check if the removeImageAllowed is boolean
-        if (! is_bool($this->removeImageAllowed)) {
+        // Check if the canRemoveImage is boolean
+        if (! is_bool($this->canRemoveImage)) {
             throw new InvalidConfigException('$removeImageAllowed variable only supports a boolean value, if you have a custom function you must return a boolean');
+        }
+
+        // Check if the canUploadImage is boolean
+        if (! is_bool($this->canUploadImage)) {
+            throw new InvalidConfigException('$canUploadImage variable only supports a boolean value, if you have a custom function you must return a boolean');
         }
     }
 }

--- a/Module.php
+++ b/Module.php
@@ -23,6 +23,13 @@ class Module extends \yii\base\Module
 	public $assetPublishedUrl;
 
     /**
+     * @var bool|mixed Variable that defines if the delete action will be available
+     * This variable default to true, to enable removal if image
+     * It is also possible to give a callable function, in which case the function will be executed
+     */
+    public $removeImageAllowed = true;
+
+    /**
      * @inheritdoc
      */
     public function init()
@@ -44,6 +51,14 @@ class Module extends \yii\base\Module
 		}
 		//set asset path
 		$this->assetPublishedUrl = (new AssetManager)->getPublishedUrl("@vendor/noam148/yii2-image-manager/assets/source");
+
+        // Check if the removeImageAllowed variable is callable
+        if (is_callable($this->removeImageAllowed)) {
+            $this->removeImageAllowed = call_user_func($this->removeImageAllowed);
+        }
+
+        // Check if the variable configuration is correct in order for the module to function
+        $this->_checkVariableConfiguration();
     }
 	
 	/**
@@ -72,15 +87,17 @@ class Module extends \yii\base\Module
 					}
 				}
 			}
+
            return true;
         }
         return false;
     }
-	
-	
-	/*
-	 * Check if extensions exists
-	 */
+
+
+    /**
+     * Check if extensions exists
+     * @throws UnknownClassException Throw error if extension is not found
+     */
 	private function _checkExtensionsExists(){
 		//kartik file uploaded is installed
 		if (!class_exists('kartik\file\FileInput')) {
@@ -94,6 +111,12 @@ class Module extends \yii\base\Module
 		if (!class_exists('yii\imagine\Image')) {
             throw new UnknownClassException("Can't find: yii\imagine\Image. Install \"yiisoft/yii2-imagine\": \"~2.0.0\"");
         }
-		
 	}
+
+	private function _checkVariableConfiguration() {
+        // Check if the removeImageAllowed is boolean
+        if (! is_bool($this->removeImageAllowed)) {
+            throw new InvalidConfigException('$removeImageAllowed variable only supports a boolean value, if you have a custom function you must return a boolean');
+        }
+    }
 }

--- a/assets/source/css/imagemanager.module.css
+++ b/assets/source/css/imagemanager.module.css
@@ -32,3 +32,5 @@
 #module-imagemanager > .row .col-options .image-info .details{}
 #module-imagemanager > .row .col-options .image-info .details .fileName{ font-weight: bold; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 #module-imagemanager > .row .col-options .image-info .pick-image-item{ margin-top: 10px; }
+
+#module-imagemanager a.delete-image-item { margin-top: 5px; }

--- a/controllers/ManagerController.php
+++ b/controllers/ManagerController.php
@@ -286,6 +286,13 @@ class ManagerController extends Controller {
 		$return = ['delete' => false];
 		//set response header
 		Yii::$app->getResponse()->format = Response::FORMAT_JSON;
+
+        // Check if the user is allowed to delete the image
+        if (! Yii::$app->controller->module->removeImageAllowed) {
+            // Return the response array to prevent from the action being executed any further
+            return $return;
+        }
+
 		//get post
 		$ImageManager_id = Yii::$app->request->post("ImageManager_id");
 		//get details

--- a/controllers/ManagerController.php
+++ b/controllers/ManagerController.php
@@ -106,12 +106,19 @@ class ManagerController extends Controller {
 	 * @return mixed
 	 */
 	public function actionUpload() {
+        //set response header
+        Yii::$app->getResponse()->format = Response::FORMAT_JSON;
+
+        // Check if the user is allowed to upload the image
+        if (Yii::$app->controller->module->canUploadImage == false) {
+            // Return the response array to prevent from the action being executed any further
+            return [];
+        }
+
 		//disable Csrf
 		Yii::$app->controller->enableCsrfValidation = false;
 		//return default
 		$return = $_FILES;
-		//set response header
-		Yii::$app->getResponse()->format = Response::FORMAT_JSON;
 		//set media path
 		$sMediaPath = \Yii::$app->imagemanager->mediaPath;
 		//create the folder
@@ -288,7 +295,7 @@ class ManagerController extends Controller {
 		Yii::$app->getResponse()->format = Response::FORMAT_JSON;
 
         // Check if the user is allowed to delete the image
-        if (! Yii::$app->controller->module->removeImageAllowed) {
+        if (Yii::$app->controller->module->canRemoveImage == false) {
             // Return the response array to prevent from the action being executed any further
             return $return;
         }

--- a/views/manager/index.php
+++ b/views/manager/index.php
@@ -52,7 +52,11 @@ $this->title = "Image manager";
 			<div class="form-group">
 				<?=Html::textInput('input-mediamanager-search', null, ['id'=>'input-mediamanager-search', 'class'=>'form-control', 'placeholder'=>Yii::t('imagemanager','Search').'...'])?>
 			</div>
-			
+
+			<?php
+				if (Yii::$app->controller->module->canUploadImage):
+			?>
+
 			<?=FileInput::widget([
 				'name' => 'imagemanagerFiles[]',
 				'id' => 'imagemanager-files',
@@ -79,8 +83,12 @@ $this->title = "Image manager";
 					}",
 					"fileuploaderror" => "function(event, data) { $('.msg-invalid-file-extension').removeClass('hide'); }",
 				],
-			])?>
-		
+			]) ?>
+
+			<?php
+				endif;
+			?>
+
 			<div class="image-info hide">
 				<div class="thumbnail">
 					<img src="#">
@@ -97,9 +105,9 @@ $this->title = "Image manager";
 					<div class="fileSize"></div>
 					<div class="dimensions"><span class="dimension-width"></span> &times; <span class="dimension-height"></span></div>
 					<?php
-						if (Yii::$app->controller->module->removeImageAllowed):
+						if (Yii::$app->controller->module->canRemoveImage):
 					?>
-						<a href="#" class="text-danger delete-image-item" ><?=Yii::t('imagemanager','Delete')?></a>
+						<a href="#" class="btn btn-xs btn-danger delete-image-item" ><span class="glyphicon glyphicon-trash" aria-hidden="true"></span> <?=Yii::t('imagemanager','Delete')?></a>
 					<?php
 						endif;
 					?>

--- a/views/manager/index.php
+++ b/views/manager/index.php
@@ -96,7 +96,13 @@ $this->title = "Image manager";
 					<div class="created"></div>
 					<div class="fileSize"></div>
 					<div class="dimensions"><span class="dimension-width"></span> &times; <span class="dimension-height"></span></div>
-					<a href="#" class="text-danger delete-image-item" ><?=Yii::t('imagemanager','Delete')?></a>
+					<?php
+						if (Yii::$app->controller->module->removeImageAllowed):
+					?>
+						<a href="#" class="text-danger delete-image-item" ><?=Yii::t('imagemanager','Delete')?></a>
+					<?php
+						endif;
+					?>
 				</div>
 				<?php if($viewMode === "iframe"): ?>
 				<a href="#" class="btn btn-primary btn-block pick-image-item"><?=Yii::t('imagemanager','Select')?></a> 


### PR DESCRIPTION
Added a variable to the module configuration in which it is possible to manage if a user can delete a image, the name for this variable is: $removeImageAllowed. This variable defaults to true, to keep backwards compatibility with current installations and to enable it by default in scenarios where this functionality is not needed.

This variable support having a direct boolean response put into it, for example from the can function from Yii::$app->user.

It is also possible to put a callable function in the variable, this function will be run to get the response from. This will make it possible to have custom code to give the response if the user has access. This is one of the possibilities:
`function() {
 $bHasAccess = false;

 // Check if user has a specific role
 if (Yii::$app->user->identity->role === 'Administrator') {
  $bHaseAccess = true;
 }

 return $bHasAccess;
}`

Before the module is run a new added function will be called to make sure the variable is in fact a boolean value, to make sure we have the correct information.

If you have any feedback to the code I have created, please tell me and I will make the changes and update this pull request.