### PR TITLE
Bug fixed in behavior function

### DIFF
--- a/models/ImageManager.php
+++ b/models/ImageManager.php
@@ -35,13 +35,19 @@ class ImageManager extends \yii\db\ActiveRecord {
             'value' => new Expression('NOW()'),
         ];
 
-        // Check if we need blamable behavior
-        if (Yii::$app->getModule('imagemanager')->setBlameableBehavior) {
-            $aBehaviors[] = [
-                'class' => BlameableBehavior::className(),
-                'createdByAttribute' => 'createdBy',
-                'updatedByAttribute' => 'modifiedBy',
-            ];
+        // Get the imagemanager module from the application
+        $moduleImageManager = Yii::$app->getModule('imagemanager');
+        /* @var $moduleImageManager Module */
+        if ($moduleImageManager !== null) {
+            // Module has been loaded
+            if ($moduleImageManager->setBlameableBehavior) {
+                // Module has blame able behavior
+                $aBehaviors[] = [
+                    'class' => BlameableBehavior::className(),
+                    'createdByAttribute' => 'createdBy',
+                    'updatedByAttribute' => 'modifiedBy',
+                ];
+            }
         }
 
 		return $aBehaviors;


### PR DESCRIPTION
Fixed a bug that caused a error when using the model, but not having the module loaded.

On my project I had the module loaded in the backend, since there users can upload images. I want to display the image only on the frontend, so I did not load the module in the frontend configuration. 

This caused a error when the module tried to determine if the blameable behavior has been enabled in the module configuration. Since the frontend didn't have the module loaded this raised a error.

This pull request adds a extra check to make sure that the module has been loaded.