### PR TITLE
Added possibility to change the DB component that is used by the image manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ yii migrate --migrationPath=@noam148/imagemanager/migrations
 		'useFilename' => true,
 		//show full url (for example in case of a API)
 		'absoluteUrl' => false,
+		'databaseComponent' => 'db' // The used database component by the image manager, this defaults to the Yii::$app->db component
 	],
 ],
 ```

--- a/components/ImageManagerGetPath.php
+++ b/components/ImageManagerGetPath.php
@@ -50,9 +50,10 @@ class ImageManagerGetPath extends Component {
 			'absoluteUrl' => $this->absoluteUrl,
 		]);
 
-		if (is_callable($this->databaseComponent))
+		if (is_callable($this->databaseComponent)) {
 		    // The database component is callable, run the user function
 		    $this->databaseComponent = call_user_func($this->databaseComponent);
+        }
 
         // Check if the user input is correct
         $this->_checkVariables();
@@ -100,16 +101,19 @@ class ImageManagerGetPath extends Component {
      */
 	private function _checkVariables() {
 	    // Check to make sure that the $databaseComponent is a string
-        if (! is_string($this->databaseComponent))
+        if (! is_string($this->databaseComponent)) {
             throw new InvalidConfigException("Image Manager Component - Init: Database component '$this->databaseComponent' is not a string");
+        }
 
         // Check to make sure that the $databaseComponent object exists
-        if (Yii::$app->get($this->databaseComponent, false) === null)
+        if (Yii::$app->get($this->databaseComponent, false) === null) {
             throw new InvalidConfigException("Image Manager Component - Init: Database component '$this->databaseComponent' does not exists in application configuration");
+        }
 
         // Check to make sure that the $databaseComponent is a yii\db\Connection object
-        if (($databaseComponentClassName = get_class(Yii::$app->get($this->databaseComponent))) !== ($connectionClassName = Connection::className()))
+        if (($databaseComponentClassName = get_class(Yii::$app->get($this->databaseComponent))) !== ($connectionClassName = Connection::className())) {
             throw new InvalidConfigException("Image Manager Component - Init: Database component '$this->databaseComponent' is not of type '$connectionClassName' instead it is '$databaseComponentClassName'");
+        }
     }
 
 }

--- a/components/ImageManagerGetPath.php
+++ b/components/ImageManagerGetPath.php
@@ -2,8 +2,11 @@
 
 namespace noam148\imagemanager\components;
 
+use Yii;
 use yii\base\Component;
 use noam148\imagemanager\models\ImageManager;
+use yii\base\InvalidConfigException;
+use yii\db\Connection;
 
 class ImageManagerGetPath extends Component { 
 
@@ -27,10 +30,16 @@ class ImageManagerGetPath extends Component {
 	 */
 	public $absoluteUrl = false;
 
-	/*
+    /**
+     * @var string The DB component name that the image model uses
+     * This defaults to the default Yii DB component: Yii::$app->db
+     * If this component is not set, the model will default to DB
+     */
+	public $databaseComponent = 'db';
+
+	/**
 	 * Init set config
 	 */
-
 	public function init() {
 		parent::init();
 		// initialize the compontent with the configuration loaded from config.php
@@ -40,6 +49,13 @@ class ImageManagerGetPath extends Component {
 			'useFilename' => $this->useFilename,
 			'absoluteUrl' => $this->absoluteUrl,
 		]);
+
+		if (is_callable($this->databaseComponent))
+		    // The database component is callable, run the user function
+		    $this->databaseComponent = call_user_func($this->databaseComponent);
+
+        // Check if the user input is correct
+        $this->_checkVariables();
 	}
 
 	/**
@@ -77,5 +93,23 @@ class ImageManagerGetPath extends Component {
 		}
 		return $return;
 	}
+
+    /**
+     * Check if the user configurable variables match the criteria
+     * @throws InvalidConfigException
+     */
+	private function _checkVariables() {
+	    // Check to make sure that the $databaseComponent is a string
+        if (! is_string($this->databaseComponent))
+            throw new InvalidConfigException("Image Manager Component - Init: Database component '$this->databaseComponent' is not a string");
+
+        // Check to make sure that the $databaseComponent object exists
+        if (Yii::$app->get($this->databaseComponent, false) === null)
+            throw new InvalidConfigException("Image Manager Component - Init: Database component '$this->databaseComponent' does not exists in application configuration");
+
+        // Check to make sure that the $databaseComponent is a yii\db\Connection object
+        if (($databaseComponentClassName = get_class(Yii::$app->get($this->databaseComponent))) !== ($connectionClassName = Connection::className()))
+            throw new InvalidConfigException("Image Manager Component - Init: Database component '$this->databaseComponent' is not of type '$connectionClassName' instead it is '$databaseComponentClassName'");
+    }
 
 }

--- a/models/ImageManager.php
+++ b/models/ImageManager.php
@@ -60,6 +60,26 @@ class ImageManager extends \yii\db\ActiveRecord {
 		return 'ImageManager';
 	}
 
+    /**
+     * Get the DB component that the model uses
+     * This function will throw error if object could not be found
+     * The DB connection defaults to DB
+     * @return null|object
+     */
+	public static function getDb() {
+        // Get the image manager object
+        $oImageManager = Yii::$app->get('imagemanager', false);
+
+        if($oImageManager === null)
+            // The image manager object has not been set
+            // The normal DB object will be returned, error will be thrown if not found
+            return Yii::$app->get('db');
+
+        // The image manager component has been loaded, the DB component that has been entered will be loaded
+        // By default this is the Yii::$app->db connection, the user can specify any other connection if needed
+        return Yii::$app->get($oImageManager->databaseComponent);
+    }
+
 	/**
 	 * @inheritdoc
 	 */

--- a/models/ImageManager.php
+++ b/models/ImageManager.php
@@ -70,10 +70,11 @@ class ImageManager extends \yii\db\ActiveRecord {
         // Get the image manager object
         $oImageManager = Yii::$app->get('imagemanager', false);
 
-        if($oImageManager === null)
+        if($oImageManager === null) {
             // The image manager object has not been set
             // The normal DB object will be returned, error will be thrown if not found
             return Yii::$app->get('db');
+        }
 
         // The image manager component has been loaded, the DB component that has been entered will be loaded
         // By default this is the Yii::$app->db connection, the user can specify any other connection if needed
@@ -112,8 +113,9 @@ class ImageManager extends \yii\db\ActiveRecord {
         parent::afterDelete();
 
         // Check if file exists
-        if (file_exists($this->getImagePathPrivate()))
+        if (file_exists($this->getImagePathPrivate())) {
             unlink($this->getImagePathPrivate());
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds the possibility to change the used DB connection by the image manager.

The variable name can either be based as a direct string, ore as a callable function.

The input is validated with the following three check
- Check if the input is a string
- Check if the given component name actually exists
- Check if the given component name is a Yii DB connection

Even if the it some how manages to pass those test, the image manager getDb() function will throw a error if the DB component does not exists, ore if not if the correct type from ActiveRecord base.

The DB connection defaults to Yii::$app->db, this way it doesnt break B.C. with current installations.